### PR TITLE
fixed bug with deleting contract type

### DIFF
--- a/app/admin/views.py
+++ b/app/admin/views.py
@@ -378,21 +378,8 @@ def manage_contract_types():
 def delete_selected_ct():
     if request.method == "POST":
         data = request.get_data()
-        data_parsed = str(data.decode("utf-8")[1:-1])
-        print(data_parsed)
+        data_parsed = str(data.decode("utf-8")[60:-4])
         ContrType.query.filter(ContrType.contract_structure_type == data_parsed).delete()
-        db.session.commit()
-
-    return ("Success")
-
-@admin.route('/delete_selected', methods=['POST'])
-@login_required
-@admin_required
-def delete_selected():
-    if request.method == "POST":
-        data = request.get_data()
-        timestamp_to_delete = str(data.decode("utf-8")[14:-2]) # Note: sensitive to name of button
-        ProfServ.query.filter(ProfServ.timestamp == timestamp_to_delete).delete()
         db.session.commit()
 
     return ("Success")
@@ -433,3 +420,15 @@ def delete_csv():
                                 smlrForm=smlrForm,
                                 slmrForm=slmrForm,
                                 dsForm=dsForm)
+
+@admin.route('/delete_selected', methods=['POST'])
+@login_required
+@admin_required
+def delete_selected():
+    if request.method == "POST":
+        data = request.get_data()
+        timestamp_to_delete = str(data.decode("utf-8")[14:-2]) # Note: sensitive to name of button
+        ProfServ.query.filter(ProfServ.timestamp == timestamp_to_delete).delete()
+        db.session.commit()
+
+    return ("Success")

--- a/app/templates/admin/manage_contract_types.html
+++ b/app/templates/admin/manage_contract_types.html
@@ -57,7 +57,7 @@
                             <tr>
                                 <td data-label="selected" style="text-align: center;">
                                     <div class="ui fitted slider checkbox">
-                                        <input class="checkbox-input" value="{{ name }}" type="checkbox"> <label></label>
+                                        <input class="checkbox-input" value="{{ type }}" type="checkbox"> <label></label>
                                     </div>
                                 </td>
                                 <td data-label="timestamp">


### PR DESCRIPTION
1) fixed bug in manage_contract_types.html to make admin able to delete contract types
2) slightly changed delete_selected_ct to be able to parse jsonified string correctly
3) slight refactoring in admin/views.py to make code more readable